### PR TITLE
Fixed actorConditions bugs

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/model/gamedata/ActorCondition.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/gamedata/ActorCondition.java
@@ -171,12 +171,12 @@ public class ActorCondition extends JSONElement {
 		if (roundEffect != null) {
 			this.round_effect = new RoundEffect();
 			if (roundEffect.get("increaseCurrentHP") != null) {
-				this.round_effect.hp_boost_max = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentHP")).get("min")));
-				this.round_effect.hp_boost_min = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentHP")).get("max")));
+				this.round_effect.hp_boost_max = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentHP")).get("max")));
+				this.round_effect.hp_boost_min = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentHP")).get("min")));
 			}
 			if (roundEffect.get("increaseCurrentAP") != null) {
-				this.round_effect.ap_boost_max = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentAP")).get("min")));
-				this.round_effect.ap_boost_min = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentAP")).get("max")));
+				this.round_effect.ap_boost_max = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentAP")).get("max")));
+				this.round_effect.ap_boost_min = JSONElement.getInteger((Number) (((Map)roundEffect.get("increaseCurrentAP")).get("min")));
 			}
 			this.round_effect.visual_effect = (String) roundEffect.get("visualEffectID");
 		}
@@ -184,12 +184,12 @@ public class ActorCondition extends JSONElement {
 		if (fullRoundEffect != null) {
 			this.full_round_effect = new RoundEffect();
 			if (fullRoundEffect.get("increaseCurrentHP") != null) {
-				this.full_round_effect.hp_boost_max = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentHP")).get("min")));
-				this.full_round_effect.hp_boost_min = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentHP")).get("max")));
+				this.full_round_effect.hp_boost_max = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentHP")).get("max")));
+				this.full_round_effect.hp_boost_min = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentHP")).get("min")));
 			}
 			if (fullRoundEffect.get("increaseCurrentAP") != null) {
-				this.full_round_effect.ap_boost_max = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentAP")).get("min")));
-				this.full_round_effect.ap_boost_min = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentAP")).get("max")));
+				this.full_round_effect.ap_boost_max = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentAP")).get("max")));
+				this.full_round_effect.ap_boost_min = JSONElement.getInteger((Number) (((Map)fullRoundEffect.get("increaseCurrentAP")).get("min")));
 			}
 			this.full_round_effect.visual_effect = (String) fullRoundEffect.get("visualEffectID");
 		}
@@ -322,14 +322,14 @@ public class ActorCondition extends JSONElement {
 				else jsonAD.put("min", 0);
 				if (this.constant_ability_effect.increase_damage_max != null) jsonAD.put("max", this.constant_ability_effect.increase_damage_max);
 				else jsonAD.put("max", 0);
-				jsonAbility.put("increaseCurrentAP", jsonAD);
+				jsonAbility.put("increaseAttackDamage", jsonAD);
 			}
 			if (this.constant_ability_effect.max_hp_boost != null) jsonAbility.put("increaseMaxHP", this.constant_ability_effect.max_hp_boost);
 			if (this.constant_ability_effect.max_ap_boost != null) jsonAbility.put("increaseMaxAP", this.constant_ability_effect.max_ap_boost);
 			if (this.constant_ability_effect.increase_move_cost != null) jsonAbility.put("increaseMoveCost", this.constant_ability_effect.increase_move_cost);
 			if (this.constant_ability_effect.increase_use_cost != null) jsonAbility.put("increaseUseItemCost", this.constant_ability_effect.increase_use_cost);
-			if (this.constant_ability_effect.increase_reequip_cost != null) jsonAbility.put("increaseUseItemCost", this.constant_ability_effect.increase_reequip_cost);
-			if (this.constant_ability_effect.increase_attack_cost != null) jsonAbility.put("increaseReequipCost", this.constant_ability_effect.increase_attack_cost);
+			if (this.constant_ability_effect.increase_reequip_cost != null) jsonAbility.put("increaseReequipCost", this.constant_ability_effect.increase_reequip_cost);
+			if (this.constant_ability_effect.increase_attack_cost != null) jsonAbility.put("increaseAttackCost", this.constant_ability_effect.increase_attack_cost);
 			if (this.constant_ability_effect.increase_critical_skill != null) jsonAbility.put("increaseCriticalSkill", this.constant_ability_effect.increase_critical_skill);
 			if (this.constant_ability_effect.increase_block_chance != null) jsonAbility.put("increaseBlockChance", this.constant_ability_effect.increase_block_chance);
 			if (this.constant_ability_effect.increase_damage_resistance != null) jsonAbility.put("increaseDamageResistance", this.constant_ability_effect.increase_damage_resistance);


### PR DESCRIPTION
- Min/max values in various places were inverted.
- Changed "increaseCurrentAP" to "increaseAttackDamage"
- Fixed wrong strings for the "reequip_cost" and the "increase_attack_cost"

Creating the actor condition before the fixes : 
![atcs1](https://cloud.githubusercontent.com/assets/10435246/6505899/d7ae1dd0-c346-11e4-9e75-a544315e556f.PNG)

Then closing ATCS and opening the actor condition again :
![atcs3](https://cloud.githubusercontent.com/assets/10435246/6505901/e09149b8-c346-11e4-99a3-f2193d548213.PNG)

Same problem with min and max values, creating the actor condition : 
![atcs5](https://cloud.githubusercontent.com/assets/10435246/6505940/3f45c3e4-c347-11e4-90a6-25477f9dae20.PNG)

Closing ATCS and re-open it : 
![atcs6](https://cloud.githubusercontent.com/assets/10435246/6505941/4265d1ea-c347-11e4-95a6-15fea70eeb04.PNG)

Now everything is fixed :+1: 
