### PR TITLE
Adjusted external map change detection

### DIFF
--- a/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMapSet.java
+++ b/src/com/gpl/rpg/atcontentstudio/model/maps/TMXMapSet.java
@@ -100,7 +100,7 @@ public class TMXMapSet implements ProjectTreeNode {
 					while(getProject().open) {
 						try {
 							watchService = FileSystems.getDefault().newWatchService();
-							/*WatchKey watchKey = */folderPath.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+							/*WatchKey watchKey = */folderPath.register(watchService, StandardWatchEventKinds.ENTRY_MODIFY, StandardWatchEventKinds.ENTRY_CREATE);
 							WatchKey wk;
 							validService: while(getProject().open) {
 								wk = watchService.poll(10, TimeUnit.SECONDS);


### PR DESCRIPTION
On some systems changes by tiled were not detected and therefore the refresh button was greyed. The reason might have been that tiled recreates the files instead of changing them.